### PR TITLE
Add support for content_scripts in pluginWebExtension

### DIFF
--- a/.changeset/spotty-points-judge.md
+++ b/.changeset/spotty-points-judge.md
@@ -1,0 +1,5 @@
+---
+"rsbuild-plugin-web-extension": patch
+---
+
+Add support for content_scripts in pluginWebExtension


### PR DESCRIPTION
This pull request adds support for content_scripts in the pluginWebExtension.

But, it not allows for the specification of multiple scripts yet.