### PR TITLE
Only set options_ui if options_page exists

### DIFF
--- a/src/manifest/parser.ts
+++ b/src/manifest/parser.ts
@@ -26,10 +26,11 @@ class ManifestParser {
       scripts: [manifest.background?.service_worker],
       type: "module",
     };
-    manifestCopy.options_ui = {
-      page: manifest.options_page,
-      browser_style: false,
-    };
+    if (manifest.options_page) {
+      manifestCopy.options_ui = {
+        page: manifest.options_page,
+      };
+    }
     manifestCopy.content_security_policy = {
       extension_pages: "script-src 'self'; object-src 'self'",
     };


### PR DESCRIPTION
Firefox will reject extensions as invalid if `options_ui` doesn't have `page`. Additionally, `browser_style` is not Firefox's support for Manifest V3 according to [this page](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui).

This change makes extensions work on (at least) the latest Firefox.